### PR TITLE
[주시현] step-3 투두리스트 만들기#2

### DIFF
--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -6,48 +6,38 @@ import modal from "../modal";
 import { applyDragAndDrop } from "../../utils/dragAndDrop";
 import { store } from "../../store/todoStore";
 
-const newTodoItem = {
-  colName: "해야할 일",
-  item: {
-    title: "추가",
-    content: "추가",
-    createdOn: "Mobile",
-  },
-};
-
 export default function App(parent, props) {
   parent.innerHTML = `
         <div class="${styles.app}">
-          <div todo-data="headerSection"></div>
-          <div todo-data="todoSection"></div>
-          <div todo-data="historySection" class="${styles.app__historySection}"></div>
-          <div todo-data="modalSection" class="${styles.app__modalSection}"></div>
+          <div todo-section="headerSection"></div>
+          <div todo-section="todoSection"></div>
+          <div todo-section="historySection" class="${styles.app__historySection}"></div>
+          <div todo-section="modalSection" class="${styles.app__modalSection}"></div>
         </div>
     `;
 
   //헤더 컴포넌트 마운트
-  const headerSection = parent.querySelector('[todo-data="headerSection"]');
-  headerSection.addEventListener("click", () => {
-    store.dispatch({ type: "plusTodoItem", payload: newTodoItem });
-  });
+  const headerSection = parent.querySelector('[todo-section="headerSection"]');
   header(headerSection, {});
 
   //todo컴포넌트 마운트
   //=> 처음에 초기값, API 모든 데이터를 넣어줘야함.
   //=> 생성, 수정, 삭제는 API요청은 있으나 다시 받아오지는 않음.
 
-  const todoSection = parent.querySelector('[todo-data="todoSection"]');
+  const todoSection = parent.querySelector('[todo-section="todoSection"]');
   todoListTable(todoSection, { todoList: store.getTodoList() });
 
   //클릭 시 History 컴포넌트 마운트
-  const historySection = parent.querySelector('[todo-data="historySection"]');
+  const historySection = parent.querySelector(
+    '[todo-section="historySection"]'
+  );
   document.addEventListener("toggleHistoryList", () => {
     historySection.classList.toggle(styles["app__historySection--show"]);
     todoHistory(historySection, {});
   });
 
   // 모달 섹션
-  const modalSection = parent.querySelector('[todo-data="modalSection"]');
+  const modalSection = parent.querySelector('[todo-section="modalSection"]');
   //배경 클릭 시 모달 삭제
   modalSection.addEventListener("click", () => {
     modalSection.style.display = "none";

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -4,6 +4,16 @@ import todoHistory from "../todoHistory";
 import todoListTable from "../todoListTable";
 import modal from "../modal";
 import { applyDragAndDrop } from "../../utils/dragAndDrop";
+import { store } from "../../store/todoStore";
+
+const newTodoItem = {
+  colName: "해야할 일",
+  item: {
+    title: "추가",
+    content: "추가",
+    createdOn: "Mobile",
+  },
+};
 
 export default function App(parent, props) {
   parent.innerHTML = `
@@ -17,13 +27,17 @@ export default function App(parent, props) {
 
   //헤더 컴포넌트 마운트
   const headerSection = parent.querySelector('[todo-data="headerSection"]');
+  headerSection.addEventListener("click", () => {
+    store.dispatch({ type: "plusTodoItem", payload: newTodoItem });
+  });
   header(headerSection, {});
 
   //todo컴포넌트 마운트
   //=> 처음에 초기값, API 모든 데이터를 넣어줘야함.
   //=> 생성, 수정, 삭제는 API요청은 있으나 다시 받아오지는 않음.
+
   const todoSection = parent.querySelector('[todo-data="todoSection"]');
-  todoListTable(todoSection, {});
+  todoListTable(todoSection, { todoList: store.getTodoList() });
 
   //클릭 시 History 컴포넌트 마운트
   const historySection = parent.querySelector('[todo-data="historySection"]');

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -3,7 +3,7 @@ import { modalTemplate } from "./template";
 export default function modal(parent, props) {
   parent.innerHTML = modalTemplate(props);
 
-  const modalSection = parent.querySelector('[todo-data="modalSection"]');
+  const modalSection = parent.querySelector('[todo-section="modalSection"]');
   modalSection.addEventListener("click", (e) => {
     //app/index.js에서 선언해준 modal전체 영역을 눌렀을 때, 모달이 꺼지는 함수를 방지
     e.stopPropagation();

--- a/src/components/modal/template.js
+++ b/src/components/modal/template.js
@@ -2,7 +2,7 @@ import styles from "./modal.module.scss";
 
 export function modalTemplate(props) {
   return `
-    <div todo-data="modalSection" class="${styles.modal}">
+    <div todo-section="modalSection" class="${styles.modal}">
       <p class="${styles.modal__modalText}">${props.msg}</p>
       <div class="${styles.modal__bottomContainer}">
         <button todo-data="cancelBtn" class="${styles["modal__btn"]} ${styles["modal__btn--inactive"]}">취소</button>

--- a/src/components/todoItem/helper.js
+++ b/src/components/todoItem/helper.js
@@ -1,3 +1,5 @@
+const limitedTextLen = 500;
+
 // checkArr의 모든 노드(인풋)의 value를 확인하고 부적절할 경우 statusNode를 disabled 상태로 만들어 줍니다
 function checkInput(checkArr, statusNode) {
   //flag = true => checkArr 모두 입력 상태
@@ -6,9 +8,9 @@ function checkInput(checkArr, statusNode) {
     if (flag && element.value.length === 0) {
       //제목, 내용 두개 중 하나라도 입력이 안되면 false
       flag = false;
-    } else if (element.value.length > 500) {
+    } else if (element.value.length > limitedTextLen) {
       //글자수 500자 수 제한
-      element.value = element.value.substring(0, 500);
+      element.value = element.value.substring(0, limitedTextLen);
       alert("최대 500자 까지 입력 가능합니다!");
     }
   }

--- a/src/components/todoItem/index.js
+++ b/src/components/todoItem/index.js
@@ -1,3 +1,4 @@
+import { store } from "../../store/todoStore";
 import {
   addTodoListItem,
   editTodoListItem,
@@ -83,6 +84,12 @@ export default function todoItem(parent, props) {
       editTodoListItem(props.todoColTitle, newItem);
       setViewMode();
     }
+    //디스패치 실행
+    //payload로 행 이름과 아이템 입력해줌
+    store.dispatch({
+      type: "plusTodoItem",
+      payload: { todoColTitle: props.todoColTitle, item: newItem },
+    });
   };
 
   // 삭제 시

--- a/src/components/todoItem/index.js
+++ b/src/components/todoItem/index.js
@@ -73,23 +73,18 @@ export default function todoItem(parent, props) {
       createdOn: detectDeviceType(),
     };
 
-    //투두 등록 로직
+    //투두 등록 로직 => 디스패치 발생
     if (props.addMode) {
-      const newReturnItem = addTodoListItem(props.todoColTitle, newItem);
-      //추가하고 추가 컴포넌트 삭제 및
-      props.onAddItem(true, newReturnItem);
+      store.dispatch({
+        type: "plusTodoItem",
+        payload: { todoColTitle: props.todoColTitle, item: newItem },
+      });
     }
     //투두 수정 로직
     else {
       editTodoListItem(props.todoColTitle, newItem);
       setViewMode();
     }
-    //디스패치 실행
-    //payload로 행 이름과 아이템 입력해줌
-    store.dispatch({
-      type: "plusTodoItem",
-      payload: { todoColTitle: props.todoColTitle, item: newItem },
-    });
   };
 
   // 삭제 시

--- a/src/components/todoItem/index.js
+++ b/src/components/todoItem/index.js
@@ -1,9 +1,4 @@
 import { store } from "../../store/todoStore";
-import {
-  addTodoListItem,
-  editTodoListItem,
-  removeTodoListItem,
-} from "../../utils/API/todoList";
 
 import {
   addCheckInput,
@@ -91,12 +86,11 @@ export default function todoItem(parent, props) {
 
   // 삭제 시
   const onErase_view = () => {
-    console.log("onerase");
     createDeleteModal(parent, () => {
-      removeTodoListItem(props.todoColTitle, props.item);
-      parent.parentNode.removeChild(parent);
-      console.log(props);
-      props.onDeleteItem();
+      store.dispatch({
+        type: "deleteTodoItem",
+        payload: { todoColTitle: props.todoColTitle, item: props.item },
+      });
     });
   };
 

--- a/src/components/todoItem/index.js
+++ b/src/components/todoItem/index.js
@@ -86,8 +86,6 @@ export default function todoItem(parent, props) {
         type: "updateTodoItem",
         payload: { todoColTitle: props.todoColTitle, item: newItem },
       });
-      //editTodoListItem(props.todoColTitle, newItem);
-      setViewMode();
     }
   };
 

--- a/src/components/todoItem/index.js
+++ b/src/components/todoItem/index.js
@@ -82,7 +82,11 @@ export default function todoItem(parent, props) {
     }
     //투두 수정 로직
     else {
-      editTodoListItem(props.todoColTitle, newItem);
+      store.dispatch({
+        type: "updateTodoItem",
+        payload: { todoColTitle: props.todoColTitle, item: newItem },
+      });
+      //editTodoListItem(props.todoColTitle, newItem);
       setViewMode();
     }
   };

--- a/src/components/todoList/helper.js
+++ b/src/components/todoList/helper.js
@@ -1,9 +1,0 @@
-const onAddCountUp = (itemCount) => {
-  itemCount.innerText = parseInt(itemCount.innerText) + 1;
-};
-
-const onDeleteCountDown = (itemCount) => {
-  itemCount.innerText = parseInt(itemCount.innerText) - 1;
-};
-
-export { onAddCountUp, onDeleteCountDown };

--- a/src/components/todoList/index.js
+++ b/src/components/todoList/index.js
@@ -1,5 +1,4 @@
 import todoItem from "../todoItem";
-import { onAddCountUp, onDeleteCountDown } from "./helper";
 import { todoListTemplate } from "./template";
 import { applyDragAndDrop } from "../../utils/dragAndDrop";
 
@@ -11,7 +10,6 @@ export default function todoList(parent, props) {
   );
 
   //행 하나에 item으로 컴포넌트를 만들어서 마운트
-  const itemCount = parent.querySelector('[todo-data="itemCount"]');
   const itemsContainer = parent.querySelector(`[todo-data="items"]`);
 
   const onAddItem = (isNew, item) => {
@@ -23,16 +21,12 @@ export default function todoList(parent, props) {
     todoItem(todoItemWrapper, {
       todoColTitle: props.title,
       item,
-      onDeleteItem: () => {
-        onDeleteCountDown(itemCount);
-      },
     });
     if (isNew) {
       // 새로운 아이템 등록 및 추가
       const referenceNode = newItemContainer.nextSibling;
       itemsContainer.insertBefore(todoItemWrapper, referenceNode);
       newItemContainer.style.display = "none";
-      onAddCountUp(itemCount);
 
       const draggables = parent.querySelectorAll('[todo-data="todoItem"]');
       const containers = parent.querySelectorAll("[todo-data='items']");

--- a/src/components/todoList/index.js
+++ b/src/components/todoList/index.js
@@ -10,7 +10,9 @@ export default function todoList(parent, props) {
     '[todo-data="newItemContainer"]'
   );
 
+  //행 하나에 item으로 컴포넌트를 만들어서 마운트
   const itemCount = parent.querySelector('[todo-data="itemCount"]');
+  const itemsContainer = parent.querySelector(`[todo-data="items"]`);
 
   const onAddItem = (isNew, item) => {
     const todoItemWrapper = document.createElement("div");
@@ -41,8 +43,6 @@ export default function todoList(parent, props) {
     }
   };
 
-  //행 하나에 item으로 컴포넌트를 만들어서 마운트
-  const itemsContainer = parent.querySelector('[todo-data="items"]');
   for (const item of props.items) {
     onAddItem(false, item);
   }

--- a/src/components/todoList/index.js
+++ b/src/components/todoList/index.js
@@ -1,6 +1,7 @@
 import todoItem from "../todoItem";
 import { onAddCountUp, onDeleteCountDown } from "./helper";
 import { todoListTemplate } from "./template";
+import { applyDragAndDrop } from "../../utils/dragAndDrop";
 
 export default function todoList(parent, props) {
   parent.innerHTML = todoListTemplate(props);
@@ -26,9 +27,14 @@ export default function todoList(parent, props) {
     });
     if (isNew) {
       // 새로운 아이템 등록 및 추가
-      newItemContainer.insertAdjacentElement("afterend", todoItemWrapper);
+      const referenceNode = newItemContainer.nextSibling;
+      itemsContainer.insertBefore(todoItemWrapper, referenceNode);
       newItemContainer.style.display = "none";
       onAddCountUp(itemCount);
+
+      const draggables = parent.querySelectorAll('[todo-data="todoItem"]');
+      const containers = parent.querySelectorAll("[todo-data='items']");
+      applyDragAndDrop(draggables, containers);
     } else {
       // 초기 데이터의 아이템 렌더시 사용
       itemsContainer.appendChild(todoItemWrapper);

--- a/src/components/todoList/index.js
+++ b/src/components/todoList/index.js
@@ -51,7 +51,6 @@ export default function todoList(parent, props) {
   const plusBtn = parent.querySelector('[todo-data="plusBtn"]');
   plusBtn.addEventListener("click", () => {
     if (newItemContainer.style.display === "none") {
-      newItemContainer.style.display = "block";
       todoItem(newItemContainer, {
         todoColTitle: props.title,
         addMode: true,
@@ -60,8 +59,8 @@ export default function todoList(parent, props) {
         },
         onAddItem,
       });
-    } else {
-      newItemContainer.style.display = "none";
     }
+    newItemContainer.style.display =
+      newItemContainer.style.display === "block" ? "none" : "block";
   });
 }

--- a/src/components/todoList/template.js
+++ b/src/components/todoList/template.js
@@ -18,7 +18,7 @@ export function todoListTemplate(props) {
         </button>
       </div>
     </div>
-    <div todo-data="items" class="${styles.todoList__content}">
+    <div todo-data="items" id="todoCol_${props.title}" class="${styles.todoList__content}">
       <div todo-data="newItemContainer" style="display:none"></div>
     </div>
   </div>

--- a/src/components/todoList/template.js
+++ b/src/components/todoList/template.js
@@ -7,7 +7,7 @@ export function todoListTemplate(props) {
     <div class="${styles.todoList__header}">
       <div class="${styles.todoList__countWrapper}">
         <h2 class="${styles.todoList__headerTitle}">${props.title}</h2>
-        <p todo-data="itemCount" class="${styles.todoList__count}">${props.items.length}</p>
+        <p id="count_${props.title}" todo-data="itemCount" class="${styles.todoList__count}">${props.items.length}</p>
       </div>
       <div class="${styles.todoList__btnContainer}">
         <button todo-data="plusBtn" class="actionBtn">

--- a/src/components/todoListTable/index.js
+++ b/src/components/todoListTable/index.js
@@ -19,14 +19,3 @@ export default function todoListTable(parent, props) {
     todoListTable.appendChild(container);
   }
 }
-
-function renderCol(todoColTitle, todoColData) {
-  const container = document.createElement("div");
-  todoList(container, {
-    title: todoColTitle,
-    items: todoColData,
-  });
-  todoListTable.appendChild(container);
-}
-
-store.subscribe(renderCol);

--- a/src/components/todoListTable/index.js
+++ b/src/components/todoListTable/index.js
@@ -11,6 +11,7 @@ export default function todoListTable(parent, props) {
 
   for (const [todoColTitle, todoColData] of todoDataEntries) {
     const container = document.createElement("div");
+    container.id = `container_${todoColTitle}`;
     todoList(container, {
       title: todoColTitle,
       items: todoColData,

--- a/src/components/todoListTable/index.js
+++ b/src/components/todoListTable/index.js
@@ -1,5 +1,5 @@
+import { store } from "../../store/todoStore";
 import todoList from "../todoList";
-import { getTodoList } from "../../utils/API/todoList";
 import { todoListTableTemplate } from "./template";
 export default function todoListTable(parent, props) {
   //행 + 데이터를 모두 감싸고 있는 컨테이너 (테이블)
@@ -7,8 +7,8 @@ export default function todoListTable(parent, props) {
 
   //데이터 API호출 후, 각 todoList에 넣어서 각각 만들어주고 그것을 마운트해준다.
   const todoListTable = parent.querySelector('[todo-data="todoListTable"]');
-  const todoData = getTodoList();
-  const todoDataEntries = Object.entries(todoData);
+  const todoDataEntries = Object.entries(props.todoList);
+
   for (const [todoColTitle, todoColData] of todoDataEntries) {
     const container = document.createElement("div");
     todoList(container, {
@@ -18,3 +18,14 @@ export default function todoListTable(parent, props) {
     todoListTable.appendChild(container);
   }
 }
+
+function renderCol(todoColTitle, todoColData) {
+  const container = document.createElement("div");
+  todoList(container, {
+    title: todoColTitle,
+    items: todoColData,
+  });
+  todoListTable.appendChild(container);
+}
+
+store.subscribe(renderCol);

--- a/src/components/todoListTable/index.js
+++ b/src/components/todoListTable/index.js
@@ -1,4 +1,3 @@
-import { store } from "../../store/todoStore";
 import todoList from "../todoList";
 import { todoListTableTemplate } from "./template";
 export default function todoListTable(parent, props) {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,3 +1,5 @@
+import todoItem from "../components/todoItem";
+
 export function createStore(initStore, reducer) {
   let state = {
     ...initStore,
@@ -7,7 +9,22 @@ export function createStore(initStore, reducer) {
 
   const dispatch = (action) => {
     state = reducer(state, action);
-    listeners.forEach((fn) => fn());
+
+    if (action.type === "plusTodoItem") {
+      const todoColTitle = action.payload.todoColTitle;
+
+      const colContainer = document.getElementById(`todoCol_${todoColTitle}`);
+      state.todoList[todoColTitle].forEach((todo) => {
+        todoItem(colContainer, {
+          todoColTitle: todo.title,
+          todo,
+          onDeleteItem: () => {
+            onDeleteCountDown(itemCount);
+          },
+        });
+      });
+    }
+    //listeners.forEach((fn) => fn());
   };
 
   const getState = () => ({ ...state });

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,0 +1,26 @@
+export function createStore(initStore, reducer) {
+  let state = {
+    ...initStore,
+  };
+
+  const listeners = [];
+
+  const dispatch = (action) => {
+    state = reducer(state, action);
+    listeners.forEach((fn) => fn());
+  };
+
+  const getState = () => ({ ...state });
+  const getHistory = () => ({ ...state.history });
+  const getTodoList = () => ({ ...state.todoList });
+
+  const subscribe = (fn) => listeners.push(fn);
+
+  return {
+    getState,
+    getTodoList,
+    getHistory,
+    dispatch,
+    subscribe,
+  };
+}

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,4 +1,4 @@
-import todoItem from "../components/todoItem";
+import { todoColListRender } from "../utils/render/todoColListRender";
 
 export function createStore(initStore, reducer) {
   let state = {
@@ -9,27 +9,26 @@ export function createStore(initStore, reducer) {
 
   const dispatch = (action) => {
     state = reducer(state, action);
-
     if (action.type === "plusTodoItem") {
-      const todoColTitle = action.payload.todoColTitle;
-
-      const colContainer = document.getElementById(`todoCol_${todoColTitle}`);
-      state.todoList[todoColTitle].forEach((todo) => {
-        todoItem(colContainer, {
-          todoColTitle: todo.title,
-          todo,
-          onDeleteItem: () => {
-            onDeleteCountDown(itemCount);
-          },
-        });
-      });
+      todoColListRender(
+        action.payload.todoColTitle,
+        getColTodoList(action.payload.todoColTitle)
+      );
     }
+
     //listeners.forEach((fn) => fn());
   };
 
   const getState = () => ({ ...state });
   const getHistory = () => ({ ...state.history });
   const getTodoList = () => ({ ...state.todoList });
+  const getColTodoList = (todoColTitle) => ({
+    ...state.todoList[todoColTitle],
+  });
+
+  const setPlusItem = (todoColTitle, item) => {
+    state.todoList[todoColTitle].unshift(item);
+  };
 
   const subscribe = (fn) => listeners.push(fn);
 
@@ -37,7 +36,9 @@ export function createStore(initStore, reducer) {
     getState,
     getTodoList,
     getHistory,
+    getColTodoList,
     dispatch,
     subscribe,
+    setPlusItem,
   };
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -5,20 +5,28 @@ export function createStore(initStore, reducer) {
     ...initStore,
   };
 
-  const listeners = [];
-
-  const dispatch = (action) => {
-    state = reducer(state, action);
-    if (action.type === "plusTodoItem") {
-      todoColListRender(
-        action.payload.todoColTitle,
-        getColTodoList(action.payload.todoColTitle)
-      );
-    }
-
-    //listeners.forEach((fn) => fn());
+  //리스너에선 어떤 액션일때 어떤 렌더링 함수를 시킬지 정함
+  const listeners = {
+    plusTodoItem: [
+      (todoColTitle, todoList) => todoColListRender(todoColTitle, todoList),
+    ],
+    updateTodoItem: [
+      (todoColTitle, todoList) => todoColListRender(todoColTitle, todoList),
+    ],
   };
 
+  //디스패치에선 reducer와 리스너를 실행
+  const dispatch = (action) => {
+    state = reducer(state, action);
+    listeners[action.type].forEach((fn) =>
+      fn(
+        action.payload.todoColTitle,
+        getColTodoList(action.payload.todoColTitle)
+      )
+    );
+  };
+
+  //get함수
   const getState = () => ({ ...state });
   const getHistory = () => ({ ...state.history });
   const getTodoList = () => ({ ...state.todoList });
@@ -26,19 +34,28 @@ export function createStore(initStore, reducer) {
     ...state.todoList[todoColTitle],
   });
 
+  //set함수
   const setPlusItem = (todoColTitle, item) => {
     state.todoList[todoColTitle].unshift(item);
   };
-
-  const subscribe = (fn) => listeners.push(fn);
+  const setUpdateItem = (todoColTitle, item) => {
+    const todoList = getTodoList()[todoColTitle];
+    for (let idx = 0; idx < todoList.length; idx++) {
+      const todo = todoList[idx];
+      if (item.id === todo.id) {
+        state.todoList[todoColTitle][idx] = item;
+        break;
+      }
+    }
+  };
 
   return {
     getState,
     getTodoList,
     getHistory,
     getColTodoList,
-    dispatch,
-    subscribe,
     setPlusItem,
+    setUpdateItem,
+    dispatch,
   };
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -14,14 +14,16 @@ export function createStore(initStore, reducer) {
       (todoColTitle, todoList) => todoColListRender(todoColTitle, todoList),
     ],
     deleteTodoItem: [
-      (todoColTitle, todoList) => todoColListRender(todoColTitle, todoList),
+      (todoId, todoColTitle, whereColIdx) =>
+        todoColListRender(todoColTitle, todoList),
     ],
+    moveTodoItem: [],
   };
 
   //디스패치에선 reducer와 리스너를 실행
   const dispatch = (action) => {
     state = reducer(state, action);
-    listeners[action.type].forEach((fn) =>
+    listeners[action.type]?.forEach((fn) =>
       fn(
         action.payload.todoColTitle,
         getColTodoList(action.payload.todoColTitle)
@@ -61,6 +63,24 @@ export function createStore(initStore, reducer) {
       }
     }
   };
+  const setChangeItem = (todoId, todoColTitle, whereColIdx) => {
+    const todoList = Object.entries(getTodoList());
+    let findColTitle, item;
+    for (let colIdx = 0; colIdx < todoList.length; colIdx++) {
+      const todoColList = todoList[colIdx][1];
+      for (let itemIdx = 0; itemIdx < todoColList.length; itemIdx++) {
+        if (todoColList[itemIdx].id === +todoId) {
+          findColTitle = todoList[colIdx][0];
+          item = todoColList[itemIdx];
+          //삭제 진행
+          state.todoList[findColTitle].splice(itemIdx, 1);
+          //수정 진행
+          state.todoList[todoColTitle].splice(whereColIdx, 0, item);
+          return;
+        }
+      }
+    }
+  };
 
   return {
     getState,
@@ -70,6 +90,7 @@ export function createStore(initStore, reducer) {
     setPlusItem,
     setUpdateItem,
     setDeleteItem,
+    setChangeItem,
     dispatch,
   };
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -13,6 +13,9 @@ export function createStore(initStore, reducer) {
     updateTodoItem: [
       (todoColTitle, todoList) => todoColListRender(todoColTitle, todoList),
     ],
+    deleteTodoItem: [
+      (todoColTitle, todoList) => todoColListRender(todoColTitle, todoList),
+    ],
   };
 
   //디스패치에선 reducer와 리스너를 실행
@@ -48,6 +51,16 @@ export function createStore(initStore, reducer) {
       }
     }
   };
+  const setDeleteItem = (todoColTitle, item) => {
+    const todoList = getTodoList()[todoColTitle];
+    for (let idx = 0; idx < todoList.length; idx++) {
+      const todo = todoList[idx];
+      if (item.id === todo.id) {
+        state.todoList[todoColTitle].splice(idx, 1);
+        break;
+      }
+    }
+  };
 
   return {
     getState,
@@ -56,6 +69,7 @@ export function createStore(initStore, reducer) {
     getColTodoList,
     setPlusItem,
     setUpdateItem,
+    setDeleteItem,
     dispatch,
   };
 }

--- a/src/store/todoStore.js
+++ b/src/store/todoStore.js
@@ -53,12 +53,21 @@ function reducer(state = {}, action) {
       ...state,
     };
   } else if (action.type === "changeTodoItem") {
-    const todoId = action.payload.todoId;
-    const todoColTitle = action.payload.todoColTitle.replace("todoCol_", "");
-    const whereColIdx = action.payload.whereColIdx;
+    const { startColIndex, todoColTitleSrc, endColIndex, todoColTitleDst } =
+      action.payload;
 
-    store.setChangeItem(todoId, todoColTitle, whereColIdx);
-    moveTodoListItem(todoId, todoColTitle, whereColIdx);
+    store.setChangeItem(
+      startColIndex,
+      todoColTitleSrc,
+      endColIndex,
+      todoColTitleDst
+    );
+    moveTodoListItem(
+      startColIndex,
+      todoColTitleSrc,
+      endColIndex,
+      todoColTitleDst
+    );
   }
 
   return state;

--- a/src/store/todoStore.js
+++ b/src/store/todoStore.js
@@ -1,0 +1,58 @@
+import { createStore } from "./store";
+
+let initStore = {
+  todoList: {
+    "해야할 일": [
+      {
+        title: "투두 아이템 제목 입니다.",
+        content: "투두 아이템 내용입니다.",
+        createdOn: "Web",
+      },
+      {
+        title: "투두 아이템 제목 입니다.",
+        content: "투두 아이템 내용입니다.",
+        createdOn: "Web",
+      },
+    ],
+    "하고 있는 일": [],
+    "완료한 일": [],
+  },
+  history: [
+    {
+      authorName: "쓴 사람 이름입니다",
+      timeStamp: 18121312312,
+      actionId: 0,
+      todoTitle: "새로운 투두",
+      todoSrc: null,
+      todoDst: null,
+    },
+  ],
+};
+
+localStorage.setItem("data", JSON.stringify(initStore));
+
+const store = createStore(initStore, reducer);
+
+// reducer함수 구현
+function reducer(state = {}, action) {
+  //값을 받아서 state에 추가
+  if (action.type === "plusTodoItem") {
+    const item = action.payload.item;
+    const todoColTitle = action.payload.todoColTitle;
+    state.todoList[todoColTitle].unshift(item);
+
+    return {
+      ...state,
+    };
+  }
+
+  return state;
+}
+
+function showState() {
+  console.log(store.getState());
+}
+
+store.subscribe(showState);
+
+export { store };

--- a/src/store/todoStore.js
+++ b/src/store/todoStore.js
@@ -3,6 +3,7 @@ import {
   addTodoListItem,
   editTodoListItem,
   removeTodoListItem,
+  moveTodoListItem,
 } from "../utils/API/todoList";
 
 let initTodoList = {
@@ -51,13 +52,16 @@ function reducer(state = {}, action) {
     return {
       ...state,
     };
+  } else if (action.type === "changeTodoItem") {
+    const todoId = action.payload.todoId;
+    const todoColTitle = action.payload.todoColTitle.replace("todoCol_", "");
+    const whereColIdx = action.payload.whereColIdx;
+
+    store.setChangeItem(todoId, todoColTitle, whereColIdx);
+    moveTodoListItem(todoId, todoColTitle, whereColIdx);
   }
 
   return state;
-}
-
-function showState() {
-  console.log(store.getState());
 }
 
 export { store };

--- a/src/store/todoStore.js
+++ b/src/store/todoStore.js
@@ -1,5 +1,5 @@
 import { createStore } from "./store";
-import { addTodoListItem } from "../utils/API/todoList";
+import { addTodoListItem, editTodoListItem } from "../utils/API/todoList";
 
 let initTodoList = {
   "해야할 일": [],
@@ -20,14 +20,22 @@ if (!existenceTodoList) {
 
 const store = createStore(inStoreData, reducer);
 
-// reducer함수 구현
+// reducer함수 => 여기선 state를 변경 + API서버로의 변경까지 진행
 function reducer(state = {}, action) {
   //값을 받아서 state에 추가
   if (action.type === "plusTodoItem") {
-    const todoColTitle = action.payload.todoColTitle;
     const item = action.payload.item;
+    const todoColTitle = action.payload.todoColTitle;
     store.setPlusItem(todoColTitle, item);
     addTodoListItem(todoColTitle, item);
+    return {
+      ...state,
+    };
+  } else if (action.type === "updateTodoItem") {
+    const item = action.payload.item;
+    const todoColTitle = action.payload.todoColTitle;
+    store.setUpdateItem(todoColTitle, item);
+    editTodoListItem(todoColTitle, item);
     return {
       ...state,
     };
@@ -39,7 +47,5 @@ function reducer(state = {}, action) {
 function showState() {
   console.log(store.getState());
 }
-
-store.subscribe(showState);
 
 export { store };

--- a/src/store/todoStore.js
+++ b/src/store/todoStore.js
@@ -1,5 +1,9 @@
 import { createStore } from "./store";
-import { addTodoListItem, editTodoListItem } from "../utils/API/todoList";
+import {
+  addTodoListItem,
+  editTodoListItem,
+  removeTodoListItem,
+} from "../utils/API/todoList";
 
 let initTodoList = {
   "해야할 일": [],
@@ -36,6 +40,14 @@ function reducer(state = {}, action) {
     const todoColTitle = action.payload.todoColTitle;
     store.setUpdateItem(todoColTitle, item);
     editTodoListItem(todoColTitle, item);
+    return {
+      ...state,
+    };
+  } else if (action.type === "deleteTodoItem") {
+    const item = action.payload.item;
+    const todoColTitle = action.payload.todoColTitle;
+    store.setDeleteItem(todoColTitle, item);
+    removeTodoListItem(todoColTitle, item);
     return {
       ...state,
     };

--- a/src/store/todoStore.js
+++ b/src/store/todoStore.js
@@ -1,46 +1,33 @@
 import { createStore } from "./store";
+import { addTodoListItem } from "../utils/API/todoList";
 
-let initStore = {
-  todoList: {
-    "해야할 일": [
-      {
-        title: "투두 아이템 제목 입니다.",
-        content: "투두 아이템 내용입니다.",
-        createdOn: "Web",
-      },
-      {
-        title: "투두 아이템 제목 입니다.",
-        content: "투두 아이템 내용입니다.",
-        createdOn: "Web",
-      },
-    ],
-    "하고 있는 일": [],
-    "완료한 일": [],
-  },
-  history: [
-    {
-      authorName: "쓴 사람 이름입니다",
-      timeStamp: 18121312312,
-      actionId: 0,
-      todoTitle: "새로운 투두",
-      todoSrc: null,
-      todoDst: null,
-    },
-  ],
+let initTodoList = {
+  "해야할 일": [],
+  "하고 있는 일": [],
+  "완료한 일": [],
 };
 
-localStorage.setItem("data", JSON.stringify(initStore));
+const existenceTodoList = JSON.parse(localStorage.getItem("todoList"));
+const existenceHistory = JSON.parse(localStorage.getItem("history"));
+let inStoreData;
+//이미 존재하는 값이 없으면 초기값으로 설정
+if (!existenceTodoList) {
+  localStorage.setItem("todoList", JSON.stringify(initTodoList));
+  inStoreData = { initStore, history: existenceHistory };
+} else {
+  inStoreData = { todoList: existenceTodoList, history: existenceHistory };
+}
 
-const store = createStore(initStore, reducer);
+const store = createStore(inStoreData, reducer);
 
 // reducer함수 구현
 function reducer(state = {}, action) {
   //값을 받아서 state에 추가
   if (action.type === "plusTodoItem") {
-    const item = action.payload.item;
     const todoColTitle = action.payload.todoColTitle;
-    state.todoList[todoColTitle].unshift(item);
-
+    const item = action.payload.item;
+    store.setPlusItem(todoColTitle, item);
+    addTodoListItem(todoColTitle, item);
     return {
       ...state,
     };

--- a/src/utils/API/todoList.js
+++ b/src/utils/API/todoList.js
@@ -58,27 +58,16 @@ function editTodoListItem(colTitle, item) {
 }
 
 // 투두 리스트 아이템 옮기기
-function moveTodoListItem(todoId, todoColTitle, whereColIdx) {
+function moveTodoListItem(
+  startColIndex,
+  todoColTitleSrc,
+  endColIndex,
+  todoColTitleDst
+) {
   let todoList = JSON.parse(localStorage.getItem("todoList"));
-  let findColTitle;
-  let item;
-
-  todoList = Object.entries(todoList);
-  for (let colIdx = 0; colIdx < todoList.length; colIdx++) {
-    const todoColList = todoList[colIdx][1];
-    for (let itemIdx = 0; itemIdx < todoColList.length; itemIdx++) {
-      if (todoColList[itemIdx].id === +todoId) {
-        findColTitle = todoList[colIdx][0];
-        item = todoColList[itemIdx];
-        todoList[colIdx][1].splice(itemIdx, 1);
-        todoList = Object.fromEntries(todoList);
-        //수정 진행
-        todoList[todoColTitle].splice(whereColIdx, 0, item);
-        localStorage.setItem("todoList", JSON.stringify(todoList));
-        return;
-      }
-    }
-  }
+  const moveItem = todoList[todoColTitleSrc].splice(startColIndex, 1);
+  todoList[todoColTitleDst].splice(endColIndex, 0, ...moveItem);
+  localStorage.setItem("todoList", JSON.stringify(todoList));
 }
 
 export {

--- a/src/utils/API/todoList.js
+++ b/src/utils/API/todoList.js
@@ -39,7 +39,8 @@ function addTodoListItem(title, item) {
 
 // 투두 리스트 아이템 제거
 function removeTodoListItem(colTitle, item) {
-  const todoData = JSON.parse(localStorage.getItem("todoList"));
+  const todos = localStorage.getItem("todoList");
+  const todoData = JSON.parse(todos);
   for (let idx = 0; idx < todoData[colTitle].length; idx++) {
     if (todoData[colTitle][idx].id === item.id) {
       todoData[colTitle].splice(idx, 1);

--- a/src/utils/API/todoList.js
+++ b/src/utils/API/todoList.js
@@ -1,17 +1,11 @@
 import { addHistory, editHistory, moveHistory, removeHistory } from "./history";
 //list에 고유한 번호를 부여하기 위한 임시 변수
-let idCount = 0;
 
 // 전체 투두리스트 불러와서 리턴
 function getTodoList() {
   const todoList = localStorage.getItem("todoList");
   if (todoList !== null) {
     const todoObject = JSON.parse(todoList);
-    Object.values(todoObject).forEach((todoColArr) => {
-      todoColArr.forEach((todo) => {
-        idCount = Math.max(idCount, todo.id);
-      });
-    });
     return todoObject;
   }
 
@@ -28,7 +22,7 @@ function getTodoList() {
 
 // 투두 리스트 아이템 추가
 function addTodoListItem(title, item) {
-  const newItem = { id: ++idCount, ...item };
+  const newItem = { id: new Date().getTime(), ...item };
   const todoData = JSON.parse(localStorage.getItem("todoList"));
   todoData[title].unshift(newItem);
   localStorage.setItem("todoList", JSON.stringify(todoData));

--- a/src/utils/API/todoList.js
+++ b/src/utils/API/todoList.js
@@ -1,5 +1,5 @@
 import { addHistory, editHistory, moveHistory, removeHistory } from "./history";
-
+import { store } from "../../store/todoStore";
 //list에 고유한 번호를 부여하기 위한 임시 변수
 let idCount = 0;
 

--- a/src/utils/API/todoList.js
+++ b/src/utils/API/todoList.js
@@ -57,13 +57,28 @@ function editTodoListItem(colTitle, item) {
   editHistory(item);
 }
 
-// FIXME: 투두 리스트 아이템 옮기기
-function moveTodoListItem(titleSrc, indexSrc, titleDst, indexDst) {
-  const todoData = JSON.parse(localStorage.getItem("todoList"));
-  const item = todoData[titleSrc].splice(indexSrc, 1)[0];
-  todoData[titleDst].splice(indexDst, 0, item);
-  localStorage.setItem("todoList", JSON.stringify(todoData));
-  moveHistory(titleSrc, titleDst, item);
+// 투두 리스트 아이템 옮기기
+function moveTodoListItem(todoId, todoColTitle, whereColIdx) {
+  let todoList = JSON.parse(localStorage.getItem("todoList"));
+  let findColTitle;
+  let item;
+
+  todoList = Object.entries(todoList);
+  for (let colIdx = 0; colIdx < todoList.length; colIdx++) {
+    const todoColList = todoList[colIdx][1];
+    for (let itemIdx = 0; itemIdx < todoColList.length; itemIdx++) {
+      if (todoColList[itemIdx].id === +todoId) {
+        findColTitle = todoList[colIdx][0];
+        item = todoColList[itemIdx];
+        todoList[colIdx][1].splice(itemIdx, 1);
+        todoList = Object.fromEntries(todoList);
+        //수정 진행
+        todoList[todoColTitle].splice(whereColIdx, 0, item);
+        localStorage.setItem("todoList", JSON.stringify(todoList));
+        return;
+      }
+    }
+  }
 }
 
 export {

--- a/src/utils/API/todoList.js
+++ b/src/utils/API/todoList.js
@@ -1,5 +1,4 @@
 import { addHistory, editHistory, moveHistory, removeHistory } from "./history";
-import { store } from "../../store/todoStore";
 //list에 고유한 번호를 부여하기 위한 임시 변수
 let idCount = 0;
 

--- a/src/utils/dragAndDrop.js
+++ b/src/utils/dragAndDrop.js
@@ -1,3 +1,5 @@
+import { store } from "../store/todoStore";
+
 export function applyDragAndDrop(draggables, containers) {
   // 컨테이너 높이 동일하게 설정
   const maxHeight = Array.from(containers).reduce((max, container) => {
@@ -15,7 +17,22 @@ export function applyDragAndDrop(draggables, containers) {
       draggable.style.opacity = 0.4;
     });
 
-    draggable.addEventListener("dragend", () => {
+    draggable.addEventListener("dragend", ({ target }) => {
+      //자식 노드 객체를 배열로 바꿈.
+      const childrenNodeArr = Array.from(target.parentNode.children);
+
+      const colTitleDst = target.parentNode.id;
+      const moveIndex = childrenNodeArr.indexOf(target);
+      const moveTodoId = target.getAttribute("value");
+      store.dispatch({
+        type: "changeTodoItem",
+        payload: {
+          todoId: moveTodoId,
+          todoColTitle: colTitleDst,
+          whereColIdx: moveIndex,
+        },
+      });
+
       draggable.classList.remove("dragging");
       draggable.style.opacity = 1;
     });

--- a/src/utils/dragAndDrop.js
+++ b/src/utils/dragAndDrop.js
@@ -11,8 +11,12 @@ export function applyDragAndDrop(draggables, containers) {
     container.style.height = `${maxHeight}px`;
   });
 
+  let todoColTitleSrc, startColIndex;
   draggables.forEach((draggable) => {
-    draggable.addEventListener("dragstart", () => {
+    draggable.addEventListener("dragstart", ({ target }) => {
+      const childrenNodeArr = Array.from(target.parentNode.children);
+      todoColTitleSrc = target.parentNode.id;
+      startColIndex = childrenNodeArr.indexOf(target) - 1;
       draggable.classList.add("dragging");
       draggable.style.opacity = 0.4;
     });
@@ -21,15 +25,15 @@ export function applyDragAndDrop(draggables, containers) {
       //자식 노드 객체를 배열로 바꿈.
       const childrenNodeArr = Array.from(target.parentNode.children);
 
-      const colTitleDst = target.parentNode.id;
-      const moveIndex = childrenNodeArr.indexOf(target);
-      const moveTodoId = target.getAttribute("value");
+      const todoColTitleDst = target.parentNode.id;
+      const endColIndex = childrenNodeArr.indexOf(target) - 1;
       store.dispatch({
         type: "changeTodoItem",
         payload: {
-          todoId: moveTodoId,
-          todoColTitle: colTitleDst,
-          whereColIdx: moveIndex,
+          startColIndex: startColIndex,
+          todoColTitleSrc: todoColTitleSrc.replace("todoCol_", ""),
+          endColIndex: endColIndex,
+          todoColTitleDst: todoColTitleDst.replace("todoCol_", ""),
         },
       });
 

--- a/src/utils/dragAndDrop.js
+++ b/src/utils/dragAndDrop.js
@@ -26,7 +26,7 @@ export function applyDragAndDrop(draggables, containers) {
       e.preventDefault();
       const afterElement = getDragAfterElement(container, e.clientY);
       const draggable = document.querySelector(".dragging");
-      if (afterElement == null) {
+      if (afterElement === null) {
         container.appendChild(draggable);
       } else {
         container.insertBefore(draggable, afterElement);

--- a/src/utils/render/todoColListRender.js
+++ b/src/utils/render/todoColListRender.js
@@ -1,6 +1,7 @@
 import todoList from "../../components/todoList";
 import { applyDragAndDrop } from "../dragAndDrop";
 export function todoColListRender(todoColTitle, todoColItems) {
+  console.log(todoColTitle, todoColItems);
   // 원하는 행을 관련 컴포넌트를 넣어준다.
   const container = document.getElementById(`container_${todoColTitle}`);
   todoList(container, {

--- a/src/utils/render/todoColListRender.js
+++ b/src/utils/render/todoColListRender.js
@@ -1,0 +1,13 @@
+import todoList from "../../components/todoList";
+import { applyDragAndDrop } from "../dragAndDrop";
+export function todoColListRender(todoColTitle, todoColItems) {
+  // 원하는 행을 관련 컴포넌트를 넣어준다.
+  const container = document.getElementById(`container_${todoColTitle}`);
+  todoList(container, {
+    title: todoColTitle,
+    items: Object.values(todoColItems),
+  });
+  const draggables = document.querySelectorAll('[todo-data="todoItem"]');
+  const containers = document.querySelectorAll("[todo-data='items']");
+  applyDragAndDrop(draggables, containers);
+}

--- a/src/utils/render/todoCountRender.js
+++ b/src/utils/render/todoCountRender.js
@@ -1,0 +1,5 @@
+export function todoCountRender(todoTitle, countValue) {
+  const countId = "count_" + todoTitle;
+  const todoCount = document.getElementById(countId);
+  todoCount.innerHTML = countValue;
+}


### PR DESCRIPTION
## PR 내용
1. Store객체 생성 및 생성, 수정, 삭제에 적용
2. Store객체 생성에 따른 필요없는 기존 코드 제거
3. 기존 아이템 id부여 방식을 timeStamp주는 방식으로 변경
4. 코드 리뷰 반영

## 구현 내용
1. Store객체 생성 및 생성, 수정, 삭제에 적용
   Store객체를 생성하였다. 플럭시 구조를 바탕으로 다음과 같이 기능하도록 설계했다.
    1) `dispatch` : 액션을 받는다면 type에 따라 reducer함수와 변수 변화에 따른 관련 랜더링 함수를 실행
    2) `reducer`: action에 따라 state를 변경해준다. => 이때 state 변경과 함께 API호출을 통해 서버에 state도 동시에 변경해준다. (현재는 서버 대신 로컬스토리지가 대신하고 있음)
     3) `get함수, set함수` => 모든 값을 변경할때는 set을 통해 예상된 형태로 변경할 수 있도록한다. 
     4) `Listener 배열` => 랜더링 함수를 실행하는데 있어서 어떤 액션에 어떤 랜더링 함수를 실행할지 담고 있는 배열
=> 이를 통해 원하는 곳에선 dispatch를 통해 기능을 실행하여 State관리와 렌더링을 동시에 진행한다.
=> 참고사항: 현재 낙관적 방식으로 서버에 성공 유무와 관계없이 State변화와 렌더링을 동시에 하고 있다. 

2. Store객체 생성에 따른 필요없는 기존 코드 제거
기존 로컬스토리지로 관리하고 있던 코드가 필요없어진 부분이 있어서 제거함.

3. 기존 아이템 id부여 방식을 `timeStamp`주는 방식으로 변경
기존 ID주는 방식을 변화하여  timeStamp를 주는 방식으로 변경

4. 코드 리뷰 반영
코드 리뷰해주신 부분을 반영함. => 개선 덜한 부분이 3가지 남아있는데 이후에 진행



## 고민 사항
- 현재 Store객체 설계 방식은  `낙관적 방식`으로 서버에 성공 유무와 관계없이 State변화와 렌더링을 동시에 하고 있다. 위와 같이 설계한 이유는 `Store객체의 존재 이유이자 장점`이 Client딴에서 State를 관리하고 이를 통해 렌더링함으로써 서버의 통신 시간 문제를 개선하기 위함으로 본인은 생각하고 있다. 이 장점을 강조하고 싶어서 낙관적 방식을 채택했는데, 만약 서버 통신과정에서 실패를 하면 Client 데이터와 Server데이터가 달라진다.
그래서 낙관적 방식이 맞는지, 서버에 데이터 송수신의 성공을 기다렸다가 진행해야 하는지 고민이다. 
각 방식이 장단점이 있어 보인다.
`Store의 사용 목적`에 대해 정확히 알 필요가 있어보인다.
- 현재는 `Subscribe함수`를 쓰지 않고 미리 리스너에 넣어놓고 시작하고 있다. Subscribe를 통해서 listener에 함수를 넣어놓고 하는데, 미리 넣어놓으면 좋은게 아닐까? 하는 생각 때문에 이렇게 개발했다. Subscribe함수를 굳이 사용하는 이유에 대해 고민중이다.
- 현재 랜더링 방식은 데이터 변경이 생기면 행 별로 랜더링 중이다. 너무 낭비인 작업 아닌가 싶다. 예를 들어 삭제를 진행한다면, 그 삭제 내용만 찾아서 삭제하는 작업, 생성 작업이라면 생성한 데이터를 가지고 그 노드만 만들어서 행에 추가하는 방식? 이 맞지 않나 싶다. 생성이라면 해당 생성된 부분에 데이터만 가지고 와서 추가할 영역에 노드를 추가하는 방식? 혹은 쉽게 행 전체를 렌더링하는 방식 뭐가 더 효율적인지에 대한 고민이 있다. 이후에 랜더링 방식에 대한 고민이 필요하다.


## 기타
